### PR TITLE
ORをUNION ALLにする

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -894,8 +894,13 @@ func getTransactions(w http.ResponseWriter, r *http.Request) {
 	} else {
 		// 1st page
 		err := tx.Select(&items,
-			"SELECT * FROM `items` WHERE (`seller_id` = ? OR `buyer_id` = ?) AND `status` IN (?,?,?,?,?) ORDER BY `created_at` DESC, `id` DESC LIMIT ?",
+			"SELECT * FROM `items` WHERE `seller_id` = ? AND `status` IN (?,?,?,?,?) UNION ALL SELECT * FROM `items` WHERE `buyer_id` = ? AND `status` IN (?,?,?,?,?) ORDER BY `created_at` DESC, `id` DESC LIMIT ?",
 			user.ID,
+			ItemStatusOnSale,
+			ItemStatusTrading,
+			ItemStatusSoldOut,
+			ItemStatusCancel,
+			ItemStatusStop,
 			user.ID,
 			ItemStatusOnSale,
 			ItemStatusTrading,

--- a/webapp/sql/01_schema.sql
+++ b/webapp/sql/01_schema.sql
@@ -33,7 +33,7 @@ CREATE TABLE `items` (
   INDEX idx_id (`id`),
   INDEX idx_category_id (`category_id`),
   INDEX idx_seller_id_status (`seller_id`, `status`),
-  INDEX idx_seller_id_buyer_id_status (`seller_id`, `buyer_id`, `status`),
+  INDEX idx_buyer_id_status (`buyer_id`, `status`),
   INDEX idx_created_at_id (`created_at`, `id`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4;
 


### PR DESCRIPTION
ORがあることでseller_id_buyer_id_statusのINDEXが効かないので、UNION ALLでWHERE句の後にINDEXが効くように修正

修正前
```
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM `items` WHERE (`seller_id` = 446 OR `buyer_id` = 446) AND `status` IN ('on_sale','trading','sold_out','cancel','stop') ORDER BY `created_at` DESC, `id` DESC LIMIT 11\G
```

修正後
```
EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM `items` WHERE `seller_id` = 446 AND `status` IN ('on_sale','trading','sold_out','cancel','stop') UNION ALL SELECT * FROM `items` WHERE `buyer_id` = 446 AND `status` IN ('on_sale','trading','sold_out','cancel','stop') ORDER BY `created_at` DESC, `id` DESC LIMIT 11\G
```