### PR TITLE
itemテーブルにstatusとcategory_idにINDEXを貼る

### DIFF
--- a/webapp/sql/01_schema.sql
+++ b/webapp/sql/01_schema.sql
@@ -34,7 +34,7 @@ CREATE TABLE `items` (
   INDEX idx_category_id (`category_id`),
   INDEX idx_seller_id_status (`seller_id`, `status`),
   INDEX idx_buyer_id_status (`buyer_id`, `status`),
-  INDEX idx_status_ category_id(`status`, `category_id`),
+  INDEX idx_status_category_id(`status`, `category_id`),
   INDEX idx_created_at_id (`created_at`, `id`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4;
 

--- a/webapp/sql/01_schema.sql
+++ b/webapp/sql/01_schema.sql
@@ -34,6 +34,7 @@ CREATE TABLE `items` (
   INDEX idx_category_id (`category_id`),
   INDEX idx_seller_id_status (`seller_id`, `status`),
   INDEX idx_buyer_id_status (`buyer_id`, `status`),
+  INDEX idx_status_ category_id(`status`, `category_id`),
   INDEX idx_created_at_id (`created_at`, `id`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4;
 


### PR DESCRIPTION
修正前
```
mysql> EXPLAIN /*!50100 PARTITIONS*/
    -> SELECT * FROM `items` WHERE `status` IN ('on_sale','sold_out') AND category_id IN (51, 52, 53, 54, 55, 56) AND (`created_at` < '2019-08-12 12:09:14'  OR (`created_at` <= '2019-08-12 12:09:14' AND `id` < 36551)) ORDER BY `created_at` DESC, `id` DESC LIMIT 49\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: items
   partitions: NULL
         type: range
possible_keys: PRIMARY,idx_id,idx_category_id,idx_created_at_id
          key: idx_created_at_id
      key_len: 13
          ref: NULL
         rows: 21919
     filtered: 4.92
        Extra: Using index condition; Using where
1 row in set, 2 warnings (0.00 sec)

mysql> select count(*) FROM `items` WHERE `status` IN ('on_sale','sold_out') AND category_id IN (51, 52, 53, 54, 55, 56) AND (`created_at` < '2019-08-12 12:09:14'  OR (`created_at` <= '2019-08-12 12:09:14' AND `id` < 36551))
    -> ;
+----------+
| count(*) |
+----------+
|     3994 |
+----------+
1 row in set (0.01 sec)
```